### PR TITLE
feat: multitenancy

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -36,6 +36,17 @@
 			"type": "shell",
 			"command": "pnpm install",
 			"group": "build"
+		},
+		{
+			"label": "TypeScript: List Files",
+			"type": "shell",
+			"command": "npx tsc --noEmit --pretty false --listFiles"
+		},
+		{
+			"label": "Next.js Build",
+			"type": "shell",
+			"command": "npx next build",
+			"group": "build"
 		}
 	]
 }

--- a/app/[locale]/[team]/page.tsx
+++ b/app/[locale]/[team]/page.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import PRReviewAssignment from "@/components/pr-review/PRReviewAssignment";
+import { useParams } from "next/navigation";
+
+export default function TeamPage() {
+	const params = useParams<{ team: string }>();
+	const teamSlug = params.team;
+	return <PRReviewAssignment teamSlug={teamSlug} />;
+}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,7 +1,28 @@
 "use client";
 
 import PRReviewAssignment from "@/components/pr-review/PRReviewAssignment";
+import CreateTeamForm from "@/components/CreateTeamForm";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useLocale } from "next-intl";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
 
 export default function Page() {
+	const router = useRouter();
+	const locale = useLocale();
+	const teams = useQuery(api.queries.getTeams) ?? [];
+
+	useEffect(() => {
+		if (teams.length > 0) {
+			router.replace(`/${locale}/${teams[0].slug}`);
+		}
+	}, [teams, router, locale]);
+
+	// If no teams, show create team form; otherwise, show fallback while redirecting
+	if (teams.length === 0) {
+		return <CreateTeamForm />;
+	}
+
 	return <PRReviewAssignment />;
 }

--- a/biome.json
+++ b/biome.json
@@ -1,12 +1,21 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
 	"vcs": {
-		"enabled": false,
+		"enabled": true,
 		"clientKind": "git",
 		"useIgnoreFile": true
 	},
 	"files": {
-		"ignoreUnknown": false
+		"ignoreUnknown": false,
+		"includes": [
+			"**",
+			"!**/.next/**",
+			"!**/node_modules/**",
+			"!**/dist/**",
+			"!**/build/**",
+			"!**/.vercel/**",
+			"!**/convex/_generated/**"
+		]
 	},
 	"formatter": {
 		"enabled": true,

--- a/components/CreateTeamForm.tsx
+++ b/components/CreateTeamForm.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { useLocale } from "next-intl";
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+function slugify(input: string): string {
+	return input
+		.toLowerCase()
+		.trim()
+		.replace(/[^a-z0-9\s-]/g, "") // remove non-alphanumerics
+		.replace(/\s+/g, "-") // spaces to hyphens
+		.replace(/-+/g, "-"); // collapse multiple hyphens
+}
+
+export default function CreateTeamForm() {
+	const router = useRouter();
+	const locale = useLocale();
+	const createTeam = useMutation(api.mutations.createTeam);
+
+	const [name, setName] = useState("");
+	const [slug, setSlug] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const derivedSlug = useMemo(
+		() => (slug ? slugify(slug) : slugify(name)),
+		[name, slug],
+	);
+
+	const onSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setSubmitting(true);
+		setError(null);
+		try {
+			const finalSlug = derivedSlug;
+			if (!name.trim() || !finalSlug) {
+				setError("Please provide a team name.");
+				setSubmitting(false);
+				return;
+			}
+			await createTeam({ name: name.trim(), slug: finalSlug });
+			router.replace(`/${locale}/${finalSlug}`);
+		} catch (err) {
+			const message =
+				err instanceof Error ? err.message : "Failed to create team";
+			setError(message);
+			setSubmitting(false);
+		}
+	};
+
+	return (
+		<div className="container mx-auto py-10 max-w-xl">
+			<Card>
+				<CardHeader>
+					<CardTitle>Create your first team</CardTitle>
+					<CardDescription>
+						Teams let you keep reviewers, tags, and history separate while
+						sharing the same database.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<form onSubmit={onSubmit} className="space-y-4">
+						<div className="space-y-2">
+							<Label htmlFor="team-name">Team name</Label>
+							<Input
+								id="team-name"
+								placeholder="e.g. Platform, Mobile, Infra"
+								value={name}
+								onChange={(e) => setName(e.target.value)}
+							/>
+						</div>
+						<div className="space-y-2">
+							<Label htmlFor="team-slug">Team slug (URL)</Label>
+							<Input
+								id="team-slug"
+								placeholder="auto-generated from name"
+								value={slug}
+								onChange={(e) => setSlug(e.target.value)}
+							/>
+							<p className="text-xs text-muted-foreground">
+								Will use: <span className="font-mono">{derivedSlug || ""}</span>
+							</p>
+						</div>
+						{error && (
+							<p className="text-sm text-destructive" role="alert">
+								{error}
+							</p>
+						)}
+						<div className="pt-2">
+							<Button type="submit" disabled={submitting}>
+								{submitting ? "Creating…" : "Create team"}
+							</Button>
+						</div>
+					</form>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/components/TeamSwitcher.tsx
+++ b/components/TeamSwitcher.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useLocale } from "next-intl";
+import { useRouter } from "next/navigation";
+import { useQuery } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+
+export function TeamSwitcher({ teamSlug }: { teamSlug?: string }) {
+	const locale = useLocale();
+	const router = useRouter();
+	const teams = useQuery(api.queries.getTeams) ?? [];
+
+	const onChange = (value: string) => {
+		router.push(`/${locale}/${value}`);
+	};
+
+	return (
+		<Select value={teamSlug} onValueChange={onChange}>
+			<SelectTrigger className="w-56">
+				<SelectValue placeholder="Select team" />
+			</SelectTrigger>
+			<SelectContent>
+				{teams.map((t: { _id: string; slug: string; name: string }) => (
+					<SelectItem key={t._id} value={t.slug}>
+						{t.name}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}

--- a/components/pr-review/DeleteReviewerDialog.tsx
+++ b/components/pr-review/DeleteReviewerDialog.tsx
@@ -22,7 +22,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { Doc } from "@/convex/_generated/dataModel";
+import type { Doc } from "@/convex/_generated/dataModel";
 
 interface DeleteReviewerDialogProps {
 	reviewers: Doc<"reviewers">[];

--- a/components/pr-review/FeedHistory.tsx
+++ b/components/pr-review/FeedHistory.tsx
@@ -5,20 +5,19 @@ import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Doc } from "@/convex/_generated/dataModel";
 import { Badge } from "@/components/ui/badge";
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-export function FeedHistory() {
+export function FeedHistory({ teamSlug }: { teamSlug?: string }) {
 	const t = useTranslations();
 
 	// Use Convex for real-time tags and assignment history
-	const tags = useQuery(api.queries.getTags) || [];
-	const assignmentHistory = useQuery(api.queries.getAssignmentHistory) || [];
+	const tags =
+		useQuery(api.queries.getTags, teamSlug ? { teamSlug } : "skip") || [];
+	const assignmentHistory =
+		useQuery(
+			api.queries.getAssignmentHistory,
+			teamSlug ? { teamSlug } : "skip",
+		) || [];
 
 	const getTagBadge = (tagId: string) => {
 		const tag = tags.find((t: Doc<"tags">) => t._id === tagId);

--- a/components/pr-review/ForceAssignDialog.tsx
+++ b/components/pr-review/ForceAssignDialog.tsx
@@ -29,6 +29,7 @@ interface ForceAssignDialogProps {
 	reviewers: Doc<"reviewers">[];
 	onDataUpdate: () => Promise<void>;
 	user?: { email: string; firstName?: string; lastName?: string } | null;
+	teamSlug?: string;
 }
 
 export function ForceAssignDialog({

--- a/components/pr-review/PRReviewAssignment.tsx
+++ b/components/pr-review/PRReviewAssignment.tsx
@@ -23,6 +23,7 @@ import { SkipConfirmationDialog } from "@/components/pr-review/SkipConfirmationD
 import { FeedHistory } from "@/components/pr-review/FeedHistory";
 import { TagManager } from "@/components/pr-review/TagManager";
 import { TrackBasedAssignment } from "@/components/pr-review/TrackBasedAssignment";
+import { TeamSwitcher } from "@/components/TeamSwitcher";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -64,7 +65,11 @@ interface BackupEntry {
 	formattedDate?: string;
 }
 
-export default function PRReviewAssignment() {
+export default function PRReviewAssignment({
+	teamSlug,
+}: {
+	teamSlug?: string;
+}) {
 	const t = useTranslations();
 	const [snapshots, setSnapshots] = useState<BackupEntry[]>([]);
 	const [snapshotsLoading, setSnapshotsLoading] = useState(false);
@@ -81,7 +86,7 @@ export default function PRReviewAssignment() {
 
 	const { user, isLoaded } = useUser();
 	const { signOut } = useClerk();
-	const { hasTags, refreshTags } = useConvexTags();
+	const { hasTags, refreshTags } = useConvexTags(teamSlug);
 
 	const userInfo = user
 		? {
@@ -113,7 +118,7 @@ export default function PRReviewAssignment() {
 		restoreFromBackup,
 		handleManualRefresh,
 		formatLastUpdated,
-	} = useConvexPRReviewData(userInfo);
+	} = useConvexPRReviewData(userInfo, teamSlug);
 
 	// Enable keyboard shortcuts
 	useKeyboardShortcuts({
@@ -320,9 +325,10 @@ export default function PRReviewAssignment() {
 	return (
 		<div className="container mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6 ">
 			<div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2">
-				<h1 className="text-3xl font-bold">
-					{t("pr.title")} - Remuneraciones Perú
-				</h1>
+				<div className="flex items-center gap-3 flex-wrap">
+					<h1 className="text-3xl font-bold">{t("pr.title")}</h1>
+					<TeamSwitcher teamSlug={teamSlug} />
+				</div>
 				<div className="flex items-center gap-2">
 					<HeaderOptionsDrawer
 						compactLayout={compactLayout}
@@ -376,6 +382,7 @@ export default function PRReviewAssignment() {
 										onToggleAbsence={handleToggleAbsence}
 										onDataUpdate={handleDataUpdate}
 										updateReviewer={updateReviewer}
+										teamSlug={teamSlug}
 									/>
 								</div>
 								<DrawerFooter className="flex flex-col gap-4">
@@ -383,6 +390,7 @@ export default function PRReviewAssignment() {
 										<TagManager
 											reviewers={reviewers}
 											onDataUpdate={handleDataUpdate}
+											teamSlug={teamSlug}
 										/>
 										<AddReviewerDialog
 											onAddReviewer={addReviewer}
@@ -489,12 +497,14 @@ export default function PRReviewAssignment() {
 								reviewers={reviewers}
 								onDataUpdate={handleDataUpdate}
 								user={userInfo}
+								teamSlug={teamSlug}
 							/>
 							{hasTags && (
 								<TrackBasedAssignment
 									reviewers={reviewers}
 									onDataUpdate={handleDataUpdate}
 									user={userInfo}
+									teamSlug={teamSlug}
 								/>
 							)}
 						</div>
@@ -502,7 +512,7 @@ export default function PRReviewAssignment() {
 
 					{/* History Section - 40% */}
 					<div className="flex-1 lg:w-[40%]">
-						<FeedHistory />
+						<FeedHistory teamSlug={teamSlug} />
 					</div>
 				</div>
 			) : (
@@ -516,6 +526,7 @@ export default function PRReviewAssignment() {
 									<TagManager
 										reviewers={reviewers}
 										onDataUpdate={handleDataUpdate}
+										teamSlug={teamSlug}
 									/>
 									<AddReviewerDialog
 										onAddReviewer={addReviewer}
@@ -590,6 +601,7 @@ export default function PRReviewAssignment() {
 								onToggleAbsence={handleToggleAbsence}
 								onDataUpdate={handleDataUpdate}
 								updateReviewer={updateReviewer}
+								teamSlug={teamSlug}
 							/>
 						</CardContent>
 					</Card>
@@ -623,17 +635,19 @@ export default function PRReviewAssignment() {
 								reviewers={reviewers}
 								onDataUpdate={handleDataUpdate}
 								user={userInfo}
+								teamSlug={teamSlug}
 							/>
 							{hasTags && (
 								<TrackBasedAssignment
 									reviewers={reviewers}
 									onDataUpdate={handleDataUpdate}
 									user={userInfo}
+									teamSlug={teamSlug}
 								/>
 							)}
 						</div>
 
-						<RecentAssignments />
+						<RecentAssignments teamSlug={teamSlug} />
 					</div>
 				</div>
 			)}

--- a/components/pr-review/RecentAssignments.tsx
+++ b/components/pr-review/RecentAssignments.tsx
@@ -20,19 +20,17 @@ interface AssignmentHistoryItem {
 		lastName?: string;
 	};
 }
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-export function RecentAssignments() {
+export function RecentAssignments({ teamSlug }: { teamSlug?: string }) {
 	const t = useTranslations();
 
 	// Use Convex for real-time assignment history
-	const assignmentHistory = useQuery(api.queries.getAssignmentHistory) || [];
+	const assignmentHistory =
+		useQuery(
+			api.queries.getAssignmentHistory,
+			teamSlug ? { teamSlug } : "skip",
+		) || [];
 
 	return (
 		<Card>

--- a/components/pr-review/ReviewersTable.tsx
+++ b/components/pr-review/ReviewersTable.tsx
@@ -3,7 +3,7 @@
 import { Check, Edit, X } from "lucide-react";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { useQuery, useMutation } from "convex/react";
+import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Doc, Id } from "@/convex/_generated/dataModel";
 import { Badge } from "@/components/ui/badge";
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/table";
 import { toast } from "@/hooks/use-toast";
 import { EditReviewerDialog } from "./EditReviewerDialog";
+import { useConvexTags } from "@/hooks/useConvexTags";
 
 interface AssignmentFeedType {
 	lastAssigned?: string; // Reviewer ID only (not full object)
@@ -36,6 +37,7 @@ interface ReviewersTableProps {
 	onToggleAbsence: (id: string) => Promise<void>;
 	onDataUpdate: () => Promise<void>;
 	updateReviewer: (id: string, name: string, email: string) => Promise<boolean>;
+	teamSlug?: string;
 }
 
 export function ReviewersTable({
@@ -48,13 +50,14 @@ export function ReviewersTable({
 	onToggleAbsence,
 	onDataUpdate,
 	updateReviewer,
+	teamSlug,
 }: ReviewersTableProps) {
 	const t = useTranslations();
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [editValue, setEditValue] = useState<number>(0);
 
 	// Use Convex for real-time tags
-	const tags = useQuery(api.queries.getTags) || [];
+	const { tags } = useConvexTags(teamSlug);
 
 	// Use Convex mutation for updating assignment count
 	const updateAssignmentCountMutation = useMutation(

--- a/components/pr-review/TagManager.tsx
+++ b/components/pr-review/TagManager.tsx
@@ -39,6 +39,7 @@ import { toast } from "@/hooks/use-toast";
 interface TagManagerProps {
 	reviewers: Doc<"reviewers">[];
 	onDataUpdate: () => Promise<void>;
+	teamSlug?: string;
 }
 
 const DEFAULT_COLORS = [
@@ -54,11 +55,16 @@ const DEFAULT_COLORS = [
 	"#6B7280", // Gray
 ];
 
-export function TagManager({ reviewers, onDataUpdate }: TagManagerProps) {
+export function TagManager({
+	reviewers,
+	onDataUpdate,
+	teamSlug,
+}: TagManagerProps) {
 	const t = useTranslations();
 
 	// Use Convex hooks for real-time data
-	const tags = useQuery(api.queries.getTags) || [];
+	const tags =
+		useQuery(api.queries.getTags, teamSlug ? { teamSlug } : "skip") || [];
 	const addTagMutation = useMutation(api.mutations.addTag);
 	const updateTagMutation = useMutation(api.mutations.updateTag);
 	const removeTagMutation = useMutation(api.mutations.removeTag);
@@ -81,6 +87,14 @@ export function TagManager({ reviewers, onDataUpdate }: TagManagerProps) {
 	const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
 	const handleAddTag = async () => {
+		if (!teamSlug) {
+			toast({
+				title: t("common.error"),
+				description: t("messages.missingTeam"),
+				variant: "destructive",
+			});
+			return;
+		}
 		if (!newTagName.trim()) {
 			toast({
 				title: t("common.error"),
@@ -93,6 +107,7 @@ export function TagManager({ reviewers, onDataUpdate }: TagManagerProps) {
 		setLoading(true);
 		try {
 			await addTagMutation({
+				teamSlug,
 				name: newTagName,
 				color: newTagColor,
 				description: newTagDescription,

--- a/components/pr-review/TrackBasedAssignment.tsx
+++ b/components/pr-review/TrackBasedAssignment.tsx
@@ -33,25 +33,18 @@ import {
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 
-// Type for tag from query (with mapped id)
-type TagFromQuery = {
-	id: Id<"tags">;
-	name: string;
-	color: string;
-	description?: string;
-	createdAt: number;
-};
-
 interface TrackBasedAssignmentProps {
 	reviewers: Doc<"reviewers">[];
 	onDataUpdate: () => Promise<void>;
 	user?: { email: string; firstName?: string; lastName?: string } | null;
+	teamSlug?: string;
 }
 
 export function TrackBasedAssignment({
 	reviewers,
 	onDataUpdate,
 	user,
+	teamSlug,
 }: TrackBasedAssignmentProps) {
 	const t = useTranslations();
 
@@ -62,11 +55,12 @@ export function TrackBasedAssignment({
 	const [isAssigning, setIsAssigning] = useState(false);
 
 	// Use Convex hooks for real-time data
-	const tags = useQuery(api.queries.getTags) || [];
+	const tags =
+		useQuery(api.queries.getTags, teamSlug ? { teamSlug } : "skip") || [];
 	const assignPRMutation = useMutation(api.mutations.assignPR);
 	const getNextReviewerByTag = useQuery(
 		api.queries.getNextReviewerByTag,
-		selectedTagId ? { tagId: selectedTagId } : "skip",
+		selectedTagId && teamSlug ? { teamSlug, tagId: selectedTagId } : "skip",
 	);
 
 	// Get next reviewer for selected tag

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -4,7 +4,6 @@ import {
 	ThemeProvider as NextThemesProvider,
 	type ThemeProviderProps,
 } from "next-themes";
-import * as React from "react";
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
 	return <NextThemesProvider {...props}>{children}</NextThemesProvider>;

--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -64,6 +64,7 @@ const BreadcrumbPage = React.forwardRef<
 	<span
 		ref={ref}
 		role="link"
+		tabIndex={0}
 		aria-disabled="true"
 		aria-current="page"
 		className={cn("font-normal text-foreground", className)}

--- a/components/ui/carousel.tsx
+++ b/components/ui/carousel.tsx
@@ -133,16 +133,14 @@ const Carousel = React.forwardRef<
 					canScrollNext,
 				}}
 			>
-				<div
+				<section
 					ref={ref}
 					onKeyDownCapture={handleKeyDown}
 					className={cn("relative", className)}
-					role="region"
-					aria-roledescription="carousel"
 					{...props}
 				>
 					{children}
-				</div>
+				</section>
 			</CarouselContext.Provider>
 		);
 	},

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -76,28 +76,22 @@ const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
 		return null;
 	}
 
-	return (
-		<style
-			dangerouslySetInnerHTML={{
-				__html: Object.entries(THEMES)
-					.map(
-						([theme, prefix]) => `
-${prefix} [data-chart=${id}] {
-${colorConfig
-	.map(([key, itemConfig]) => {
-		const color =
-			itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
-			itemConfig.color;
-		return color ? `  --color-${key}: ${color};` : null;
-	})
-	.join("\n")}
-}
-`,
-					)
-					.join("\n"),
-			}}
-		/>
-	);
+	const cssText = Object.entries(THEMES)
+		.map(([theme, prefix]) => {
+			const vars = colorConfig
+				.map(([key, itemConfig]) => {
+					const color =
+						itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+						itemConfig.color;
+					return color ? `  --color-${key}: ${color};` : null;
+				})
+				.filter(Boolean)
+				.join("\n");
+			return `${prefix} [data-chart=${id}] {\n${vars}\n}`;
+		})
+		.join("\n");
+
+	return <style>{cssText}</style>;
 };
 
 const ChartTooltip = RechartsPrimitive.Tooltip;

--- a/components/ui/input-otp.tsx
+++ b/components/ui/input-otp.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { OTPInput, OTPInputContext } from "input-otp";
-import { Dot } from "lucide-react";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -59,13 +58,9 @@ const InputOTPSlot = React.forwardRef<
 InputOTPSlot.displayName = "InputOTPSlot";
 
 const InputOTPSeparator = React.forwardRef<
-	React.ElementRef<"div">,
-	React.ComponentPropsWithoutRef<"div">
->(({ ...props }, ref) => (
-	<div ref={ref} role="separator" {...props}>
-		<Dot />
-	</div>
-));
+	React.ElementRef<"hr">,
+	React.ComponentPropsWithoutRef<"hr">
+>(({ ...props }, ref) => <hr ref={ref} {...props} />);
 InputOTPSeparator.displayName = "InputOTPSeparator";
 
 export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator };

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -5,7 +5,6 @@ import { cn } from "@/lib/utils";
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
 	<nav
-		role="navigation"
 		aria-label="pagination"
 		className={cn("mx-auto flex w-full justify-center", className)}
 		{...props}

--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -33,21 +33,21 @@ type ActionType = typeof actionTypes;
 
 type Action =
 	| {
-			type: ActionType["ADD_TOAST"];
-			toast: ToasterToast;
-	  }
+		type: ActionType["ADD_TOAST"];
+		toast: ToasterToast;
+	}
 	| {
-			type: ActionType["UPDATE_TOAST"];
-			toast: Partial<ToasterToast>;
-	  }
+		type: ActionType["UPDATE_TOAST"];
+		toast: Partial<ToasterToast>;
+	}
 	| {
-			type: ActionType["DISMISS_TOAST"];
-			toastId?: ToasterToast["id"];
-	  }
+		type: ActionType["DISMISS_TOAST"];
+		toastId?: ToasterToast["id"];
+	}
 	| {
-			type: ActionType["REMOVE_TOAST"];
-			toastId?: ToasterToast["id"];
-	  };
+		type: ActionType["REMOVE_TOAST"];
+		toastId?: ToasterToast["id"];
+	};
 
 interface State {
 	toasts: ToasterToast[];
@@ -105,9 +105,9 @@ export const reducer = (state: State, action: Action): State => {
 				toasts: state.toasts.map((t) =>
 					t.id === toastId || toastId === undefined
 						? {
-								...t,
-								open: false,
-							}
+							...t,
+							open: false,
+						}
 						: t,
 				),
 			};
@@ -179,7 +179,7 @@ function useToast() {
 				listeners.splice(index, 1);
 			}
 		};
-	}, [state]);
+	}, []);
 
 	return {
 		...state,

--- a/convex/actions.ts
+++ b/convex/actions.ts
@@ -118,6 +118,7 @@ export const forceAssignPR = action({
 // Action to assign PR by tag
 export const assignPRByTag = action({
     args: {
+        teamSlug: v.string(),
         tagId: v.id("tags"),
         actionBy: v.optional(v.object({
             email: v.string(),
@@ -125,9 +126,9 @@ export const assignPRByTag = action({
             lastName: v.optional(v.string()),
         })),
     },
-    handler: async (ctx, { tagId, actionBy }): Promise<{ success: boolean; reviewer?: Doc<"reviewers">; error?: string }> => {
+    handler: async (ctx, { teamSlug, tagId, actionBy }): Promise<{ success: boolean; reviewer?: Doc<"reviewers">; error?: string }> => {
         // Get next reviewer by tag
-        const nextReviewer = await ctx.runQuery(api.queries.getNextReviewerByTag, { tagId });
+        const nextReviewer = await ctx.runQuery(api.queries.getNextReviewerByTag, { teamSlug, tagId });
 
         if (!nextReviewer) {
             return { success: false };
@@ -150,11 +151,12 @@ export const assignPRByTag = action({
 // Action to skip to next reviewer
 export const skipToNextReviewer = action({
     args: {
+        teamSlug: v.string(),
         currentNextId: v.id("reviewers"),
     },
-    handler: async (ctx, { currentNextId }): Promise<{ success: boolean; nextReviewer?: Doc<"reviewers"> }> => {
+    handler: async (ctx, { teamSlug, currentNextId }): Promise<{ success: boolean; nextReviewer?: Doc<"reviewers"> }> => {
         // Get all reviewers
-        const reviewers = await ctx.runQuery(api.queries.getReviewers, {});
+        const reviewers = await ctx.runQuery(api.queries.getReviewers, { teamSlug });
 
         // Filter out absent reviewers and the current next reviewer
         const availableReviewers = reviewers.filter(

--- a/convex/migration.ts
+++ b/convex/migration.ts
@@ -1,15 +1,16 @@
 import { action } from "./_generated/server";
 import { api } from "./_generated/api";
+import { v } from "convex/values";
 
 export const migrateFromRedis = action({
-    args: {},
-    handler: async (ctx) => {
+    args: { teamSlug: v.string() },
+    handler: async (ctx, { teamSlug }) => {
         try {
             // This action can be called from a migration script
             // to transfer existing Redis data to Convex
 
             // For now, just initialize with default data
-            await ctx.runMutation(api.mutations.initializeData, {});
+            await ctx.runMutation(api.mutations.initializeData, { teamSlug });
 
             return { success: true, message: "Migration completed" };
         } catch (error) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2,23 +2,36 @@ import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
 
 export default defineSchema({
+    teams: defineTable({
+        name: v.string(),
+        slug: v.string(),
+        createdAt: v.optional(v.number())
+    })
+        .index("by_slug", ["slug"]) // enforce uniqueness at write-time
+        .index("by_created_at", ["createdAt"]),
     reviewers: defineTable({
+        teamId: v.optional(v.id("teams")),
         name: v.string(),
         email: v.string(),
         assignmentCount: v.number(),
         isAbsent: v.boolean(),
         createdAt: v.number(),
         tags: v.array(v.id("tags")),
-    }).index("by_email", ["email"]),
+    })
+        .index("by_email", ["email"]) // legacy/simple lookups
+        .index("by_team", ["teamId"]) // team-scoped listing
+        .index("by_team_email", ["teamId", "email"]),
 
     tags: defineTable({
+        teamId: v.optional(v.id("teams")),
         name: v.string(),
         color: v.string(),
         description: v.optional(v.string()),
         createdAt: v.number(),
-    }),
+    }).index("by_team", ["teamId"]),
 
     assignmentHistory: defineTable({
+        teamId: v.optional(v.id("teams")),
         reviewerId: v.id("reviewers"),
         reviewerName: v.string(),
         timestamp: v.number(),
@@ -31,9 +44,12 @@ export default defineSchema({
             firstName: v.optional(v.string()),
             lastName: v.optional(v.string()),
         })),
-    }).index("by_timestamp", ["timestamp"]),
+    })
+        .index("by_timestamp", ["timestamp"]) // legacy
+        .index("by_team_timestamp", ["teamId", "timestamp"]),
 
     assignmentFeed: defineTable({
+        teamId: v.optional(v.id("teams")),
         lastAssigned: v.optional(v.string()), // Store just the reviewer ID
         items: v.array(v.object({
             reviewerId: v.string(),
@@ -49,9 +65,10 @@ export default defineSchema({
                 lastName: v.optional(v.string()),
             })),
         })),
-    }),
+    }).index("by_team", ["teamId"]),
 
     backups: defineTable({
+        teamId: v.optional(v.id("teams")),
         reviewers: v.array(v.object({
             id: v.string(),
             name: v.string(),
@@ -63,5 +80,5 @@ export default defineSchema({
         })),
         reason: v.string(),
         createdAt: v.number(),
-    }).index("by_created_at", ["createdAt"]),
+    }).index("by_created_at", ["createdAt"]).index("by_team", ["teamId"]),
 });

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -33,21 +33,21 @@ type ActionType = typeof actionTypes;
 
 type Action =
 	| {
-			type: ActionType["ADD_TOAST"];
-			toast: ToasterToast;
-	  }
+		type: ActionType["ADD_TOAST"];
+		toast: ToasterToast;
+	}
 	| {
-			type: ActionType["UPDATE_TOAST"];
-			toast: Partial<ToasterToast>;
-	  }
+		type: ActionType["UPDATE_TOAST"];
+		toast: Partial<ToasterToast>;
+	}
 	| {
-			type: ActionType["DISMISS_TOAST"];
-			toastId?: ToasterToast["id"];
-	  }
+		type: ActionType["DISMISS_TOAST"];
+		toastId?: ToasterToast["id"];
+	}
 	| {
-			type: ActionType["REMOVE_TOAST"];
-			toastId?: ToasterToast["id"];
-	  };
+		type: ActionType["REMOVE_TOAST"];
+		toastId?: ToasterToast["id"];
+	};
 
 interface State {
 	toasts: ToasterToast[];
@@ -105,9 +105,9 @@ export const reducer = (state: State, action: Action): State => {
 				toasts: state.toasts.map((t) =>
 					t.id === toastId || toastId === undefined
 						? {
-								...t,
-								open: false,
-							}
+							...t,
+							open: false,
+						}
 						: t,
 				),
 			};
@@ -179,7 +179,7 @@ function useToast() {
 				listeners.splice(index, 1);
 			}
 		};
-	}, [state]);
+	}, []);
 
 	return {
 		...state,

--- a/hooks/useConvexTags.ts
+++ b/hooks/useConvexTags.ts
@@ -3,9 +3,9 @@
 import { useQuery } from "convex/react";
 import { api } from "../convex/_generated/api";
 
-export function useConvexTags() {
+export function useConvexTags(teamSlug?: string) {
     // Queries - these are automatically reactive and cached
-    const tags = useQuery(api.queries.getTags) ?? [];
+    const tags = useQuery(api.queries.getTags, teamSlug ? { teamSlug } : "skip") ?? [];
     const loading = tags === undefined;
 
     // No need for manual refresh since Convex provides real-time updates

--- a/messages/en.json
+++ b/messages/en.json
@@ -186,7 +186,8 @@
     "skipAbsentFailedDescription": "Failed to skip absent reviewer. Please try again.",
     "actions": "Actions",
     "manageData": "Manage Data",
-    "exportData": "Export Data"
+  "exportData": "Export Data",
+  "missingTeam": "No team selected. Please pick or create a team first."
   },
   "history": {
     "title": "Assignment History",

--- a/messages/es.json
+++ b/messages/es.json
@@ -234,7 +234,8 @@
     "skipAbsentFailedDescription": "Falló al omitir el revisor ausente. Por favor intenta de nuevo.",
     "actions": "Acciones",
     "manageData": "Gestionar Datos",
-    "exportData": "Exportar Datos"
+  "exportData": "Exportar Datos",
+  "missingTeam": "No hay equipo seleccionado. Primero elige o crea un equipo."
   },
   "history": {
     "title": "Historial de Asignaciones",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 		"resolveJsonModule": true,
 		"isolatedModules": true,
 		"jsx": "preserve",
-		"incremental": true,
+		"incremental": false,
 		"plugins": [
 			{
 				"name": "next"


### PR DESCRIPTION
This pull request introduces multi-team support to the PR review assignment app, allowing users to create and switch between teams, and ensuring all data is scoped to the selected team. The changes include new UI components for team creation and switching, updates to data-fetching hooks and queries to accept a `teamSlug`, and refactoring of key components to propagate the team context throughout the app.

**Multi-team support and UI enhancements**
* Added a `CreateTeamForm` component and logic to prompt users to create a team if none exist, and redirect to the first team if available (`components/CreateTeamForm.tsx`, `app/[locale]/page.tsx`). ([components/CreateTeamForm.tsxR1-R112](diffhunk://#diff-6c838b04319df7d7498cd10b15425b00c735e1c703556512666379d06c1ddf4aR1-R112), [app/[locale]/page.tsxR4-R26](diffhunk://#diff-6fbfba030614a776ef872a9fd818b8312fecd33e7054d62bd6ba952160fa764aR4-R26))
* Introduced a `TeamSwitcher` component to allow users to switch between teams from the UI, integrated into the main header (`components/TeamSwitcher.tsx`, `components/pr-review/PRReviewAssignment.tsx`). [[1]](diffhunk://#diff-283d04a6b135049de22e4ee7d88f2ea57474d699f9f31538d4529e2a5beca83fR1-R38) [[2]](diffhunk://#diff-5fe0061c58f8803ca8a1e65ea67512ad88539e54b1808b75d16a46bfe685b1bcL323-R331)

**Data scoping and propagation**
* Refactored all major components (`PRReviewAssignment`, `FeedHistory`, `RecentAssignments`, `ReviewersTable`, `TagManager`, `TrackBasedAssignment`, etc.) to accept and use a `teamSlug` prop, ensuring queries and mutations are team-specific (`components/pr-review/PRReviewAssignment.tsx`, `components/pr-review/FeedHistory.tsx`, `components/pr-review/RecentAssignments.tsx`, `components/pr-review/ReviewersTable.tsx`, `components/pr-review/TagManager.tsx`). [[1]](diffhunk://#diff-5fe0061c58f8803ca8a1e65ea67512ad88539e54b1808b75d16a46bfe685b1bcL67-R72) [[2]](diffhunk://#diff-5fe0061c58f8803ca8a1e65ea67512ad88539e54b1808b75d16a46bfe685b1bcR385-R393) [[3]](diffhunk://#diff-5fe0061c58f8803ca8a1e65ea67512ad88539e54b1808b75d16a46bfe685b1bcR500-R515) [[4]](diffhunk://#diff-5fe0061c58f8803ca8a1e65ea67512ad88539e54b1808b75d16a46bfe685b1bcR638-R650) [[5]](diffhunk://#diff-f790f6b23239245fc20f064d855b4a639222aca1ae18e90ae6385c576fe1ce42L23-R33) [[6]](diffhunk://#diff-5d87b0096e4868adc0742ade62275d3054782296e9a8377793fa9122216401dcR40) [[7]](diffhunk://#diff-704a137d2220321d981bfe6d419508638b3f7d7fb34fda36bd23a70473724e15R42) [[8]](diffhunk://#diff-704a137d2220321d981bfe6d419508638b3f7d7fb34fda36bd23a70473724e15L57-R67)

**Improved error handling and UX**
* Added error handling in tag creation to prevent actions when no team is selected and to provide user feedback (`TagManager`).
* Updated query calls to skip fetching when `teamSlug` is not available, improving performance and preventing unnecessary requests. [[1]](diffhunk://#diff-1192e4841dd185722eebf0f8975e797540887e34c0aa0cfd5ec9dbaa750404efL8-R20) [[2]](diffhunk://#diff-f790f6b23239245fc20f064d855b4a639222aca1ae18e90ae6385c576fe1ce42L23-R33) [[3]](diffhunk://#diff-704a137d2220321d981bfe6d419508638b3f7d7fb34fda36bd23a70473724e15L57-R67)

**Code and configuration cleanup**
* Changed some imports to use `type` for better type-only import separation and reduced card UI imports for cleaner code (`DeleteReviewerDialog`, `FeedHistory`, `RecentAssignments`). [[1]](diffhunk://#diff-51f021a71f6d6120a3d4826fa34fbfb4423f5e33cac7ab02b9272ae07deb7ff1L25-R25) [[2]](diffhunk://#diff-1192e4841dd185722eebf0f8975e797540887e34c0aa0cfd5ec9dbaa750404efL8-R20) [[3]](diffhunk://#diff-f790f6b23239245fc20f064d855b4a639222aca1ae18e90ae6385c576fe1ce42L23-R33)
* Updated `biome.json` and `.vscode/tasks.json` for improved tooling and file inclusion/exclusion. [[1]](diffhunk://#diff-2bc8a1f5e9380d5a187a4e90f11b4dd36c3abad6aea44c84be354a4f44cdec55L4-R18) [[2]](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aR39-R49)

**Encoded references:**  
[[1]](diffhunk://#diff-6c838b04319df7d7498cd10b15425b00c735e1c703556512666379d06c1ddf4aR1-R112) [app/[locale]/page.tsxR4-R26](diffhunk://#diff-6fbfba030614a776ef872a9fd818b8312fecd33e7054d62bd6ba952160fa764aR4-R26), [[2]](diffhunk://#diff-283d04a6b135049de22e4ee7d88f2ea57474d699f9f31538d4529e2a5beca83fR1-R38) [[3]](diffhunk://#diff-5fe0061c58f8803ca8a1e65ea67512ad88539e54b1808b75d16a46bfe685b1bcL323-R331) [[4]](diffhunk://#diff-5fe0061c58f8803ca8a1e65ea67512ad88539e54b1808b75d16a46bfe685b1bcL67-R72) [[5]](diffhunk://#diff-5fe0061c58f8803ca8a1e65ea67512ad88539e54b1808b75d16a46bfe685b1bcR385-R393) [[6]](diffhunk://#diff-5fe0061c58f8803ca8a1e65ea67512ad88539e54b1808b75d16a46bfe685b1bcR500-R515) [[7]](diffhunk://#diff-5fe0061c58f8803ca8a1e65ea67512ad88539e54b1808b75d16a46bfe685b1bcR638-R650) [[8]](diffhunk://#diff-f790f6b23239245fc20f064d855b4a639222aca1ae18e90ae6385c576fe1ce42L23-R33) [[9]](diffhunk://#diff-5d87b0096e4868adc0742ade62275d3054782296e9a8377793fa9122216401dcR40) [[10]](diffhunk://#diff-704a137d2220321d981bfe6d419508638b3f7d7fb34fda36bd23a70473724e15R42) [[11]](diffhunk://#diff-704a137d2220321d981bfe6d419508638b3f7d7fb34fda36bd23a70473724e15L57-R67) [[12]](diffhunk://#diff-704a137d2220321d981bfe6d419508638b3f7d7fb34fda36bd23a70473724e15R90-R97) [[13]](diffhunk://#diff-1192e4841dd185722eebf0f8975e797540887e34c0aa0cfd5ec9dbaa750404efL8-R20) [[14]](diffhunk://#diff-51f021a71f6d6120a3d4826fa34fbfb4423f5e33cac7ab02b9272ae07deb7ff1L25-R25) [[15]](diffhunk://#diff-2bc8a1f5e9380d5a187a4e90f11b4dd36c3abad6aea44c84be354a4f44cdec55L4-R18) [[16]](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aR39-R49)