### PR TITLE
cambiar el text y border al hacer hover del badge de asignaciones

### DIFF
--- a/components/pr-review/RecentAssignments.tsx
+++ b/components/pr-review/RecentAssignments.tsx
@@ -69,17 +69,17 @@ export function RecentAssignments({ teamSlug }: { teamSlug?: string }) {
 									</div>
 									<div>
 										{item.forced && (
-											<Badge className="bg-amber-50 text-amber-700 border-amber-200">
+											<Badge className="bg-amber-50 text-amber-700 border-amber-200 hover:border-transparent hover:text-white">
 												{t("pr.forceAssign")}
 											</Badge>
 										)}
 										{item.skipped && (
-											<Badge className="bg-blue-50 text-blue-700 border-blue-200">
+											<Badge className="bg-blue-50 text-blue-700 border-blue-200 hover:border-transparent hover:text-white">
 												{t("pr.skip")}
 											</Badge>
 										)}
 										{!item.forced && !item.skipped && (
-											<Badge className="bg-green-50 text-green-700 border-green-200">
+											<Badge className="bg-green-50 text-green-700 border-green-200 hover:border-transparent hover:text-white">
 												Regular
 											</Badge>
 										)}


### PR DESCRIPTION
Hace mas legibles los badges de la sección de asignaciones al hacer hover sobre ellos.

# Antes
<img width="199" height="194" alt="image" src="https://github.com/user-attachments/assets/c1936875-50cf-46f1-80f4-b576ecdff276" />


# Despues
<img width="246" height="356" alt="image" src="https://github.com/user-attachments/assets/7a305bcf-c7b2-4ef3-ab3e-eba7d5d54293" />
